### PR TITLE
feature: implement register file write

### DIFF
--- a/riscv.tlv
+++ b/riscv.tlv
@@ -26,6 +26,7 @@
    // Test result value in x14, and set x31 to reflect pass/fail.
    m4_asm(ADDI, x30, x14, 111111010100) // Subtract expected value of 44 to set x30 to 1 if and only iff the result is 45 (1 + 2 + ... + 9).
    m4_asm(BGE, x0, x0, 0) // Done. Jump to itself (infinite loop). (Up to 20-bit signed immediate plus implicit 0 bit (unlike JALR) provides byte address; last immediate bit should also be 0)
+   m4_asm(ADDI, x0, x0, 1)              // Test x0 is always equal to 0
    m4_asm_end()
    m4_define(['M4_MAX_CYC'], 50)
    //---------------------------------------------------------------------------------
@@ -91,16 +92,21 @@
    $is_add  = $dec_bits ==? 11'b0_000_0110011;
    
    // register file read
-   m4+rf(32, 32, $reset, $rd_valid, $rd, $wr_data[31:0], $rs1_valid, $rs1, $src1_value[31:0], $rs2_valid, $rs2, $src2_value[31:0])
+   m4+rf(32, 32, $reset, $rd_en, $rd, $wr_data[31:0], $rs1_valid, $rs1, $src1_value[31:0], $rs2_valid, $rs2, $src2_value[31:0])
    
    // alu
    $result[31:0] = $is_addi ? $src1_value + $imm :
                    $is_add  ? $src1_value + $src2_value:
                    32'b0;
    
+   // register file write
+   $wr_data[31:0] = $result;
+   $rd_en = $rd_valid && ($rd != 5'b0);
+   
+   
+   
    `BOGUS_USE($imm_valid);
    `BOGUS_USE($is_beq $is_bne $is_blt $is_bge $is_bltu $is_bgeu)
-   $wr_data[31:0] = $result;
    
    // Assert these to end simulation (before Makerchip cycle limit).
    *passed = 1'b0;


### PR DESCRIPTION
Register file write 기능 구현
* ALU의 실행 결과값 `$result`를 `$rd`에 저장
* 만약 `$rd`가 `x0`일 경우, register file에 쓰지 않음